### PR TITLE
Шкуринская Елена. Задача 1. Вариант 25. Подсчет числа предложений в строке.

### DIFF
--- a/tasks/mpi/shkurinskaya_e_count_sentences/func_tests/main.cpp
+++ b/tasks/mpi/shkurinskaya_e_count_sentences/func_tests/main.cpp
@@ -43,8 +43,7 @@ TEST(shkurinskaya_e_count_sentences_mpi, Test_Count_Sentences) {
     testMpiTaskSequential.run();
     testMpiTaskSequential.post_processing();
 
-    
-    ASSERT_EQ(global_result[0], reference_result[0]); 
+    ASSERT_EQ(global_result[0], reference_result[0]);
   }
 }
 
@@ -56,7 +55,6 @@ TEST(shkurinskaya_e_count_sentences_mpi, Test_Empty_Text) {
   // Create TaskData for parallel execution
   std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {
-    input_text = "";
     taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&input_text));
     taskDataPar->inputs_count.emplace_back(input_text.size());
     taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_result.data()));
@@ -84,8 +82,7 @@ TEST(shkurinskaya_e_count_sentences_mpi, Test_Empty_Text) {
     testMpiTaskSequential.run();
     testMpiTaskSequential.post_processing();
 
-    
-    ASSERT_EQ(global_result[0], reference_result[0]);  
+    ASSERT_EQ(global_result[0], reference_result[0]);
   }
 }
 
@@ -97,7 +94,7 @@ TEST(shkurinskaya_e_count_sentences_mpi, Test_Multiple_Endings) {
   // Create TaskData for parallel execution
   std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {
-    input_text = "Wow!!! Really??! That's amazing.";
+    input_text = "Wow!! Really?! That's amazing.";
     taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&input_text));
     taskDataPar->inputs_count.emplace_back(input_text.size());
     taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_result.data()));
@@ -125,8 +122,7 @@ TEST(shkurinskaya_e_count_sentences_mpi, Test_Multiple_Endings) {
     testMpiTaskSequential.run();
     testMpiTaskSequential.post_processing();
 
-    
-    ASSERT_EQ(global_result[0], reference_result[0]);  
+    ASSERT_EQ(global_result[0], reference_result[0]);
   }
 }
 
@@ -166,8 +162,7 @@ TEST(shkurinskaya_e_count_sentences_mpi, Test_Single_Sentence) {
     testMpiTaskSequential.run();
     testMpiTaskSequential.post_processing();
 
-    
-    ASSERT_EQ(global_result[0], reference_result[0]);  
+    ASSERT_EQ(global_result[0], reference_result[0]);
   }
 }
 
@@ -206,8 +201,7 @@ TEST(shkurinskaya_e_count_sentences_mpi, Test_No_Punctuation) {
     testMpiTaskSequential.pre_processing();
     testMpiTaskSequential.run();
     testMpiTaskSequential.post_processing();
-
     
-    ASSERT_EQ(global_result[0], reference_result[0]);  
+    ASSERT_EQ(global_result[0], reference_result[0]);
   }
 }

--- a/tasks/mpi/shkurinskaya_e_count_sentences/func_tests/main.cpp
+++ b/tasks/mpi/shkurinskaya_e_count_sentences/func_tests/main.cpp
@@ -43,8 +43,8 @@ TEST(shkurinskaya_e_count_sentences_mpi, Test_Count_Sentences) {
     testMpiTaskSequential.run();
     testMpiTaskSequential.post_processing();
 
-    // Проверка результатов
-    ASSERT_EQ(global_result[0], reference_result[0]);  // Ожидаем одинаковое количество предложений
+    
+    ASSERT_EQ(global_result[0], reference_result[0]); 
   }
 }
 
@@ -84,8 +84,8 @@ TEST(shkurinskaya_e_count_sentences_mpi, Test_Empty_Text) {
     testMpiTaskSequential.run();
     testMpiTaskSequential.post_processing();
 
-    // Проверка результатов
-    ASSERT_EQ(global_result[0], reference_result[0]);  // Ожидаем одинаковое количество предложений
+    
+    ASSERT_EQ(global_result[0], reference_result[0]);  
   }
 }
 
@@ -125,8 +125,8 @@ TEST(shkurinskaya_e_count_sentences_mpi, Test_Multiple_Endings) {
     testMpiTaskSequential.run();
     testMpiTaskSequential.post_processing();
 
-    // Проверка результатов
-    ASSERT_EQ(global_result[0], reference_result[0]);  // Ожидаем одинаковое количество предложений
+    
+    ASSERT_EQ(global_result[0], reference_result[0]);  
   }
 }
 
@@ -166,8 +166,8 @@ TEST(shkurinskaya_e_count_sentences_mpi, Test_Single_Sentence) {
     testMpiTaskSequential.run();
     testMpiTaskSequential.post_processing();
 
-    // Проверка результатов
-    ASSERT_EQ(global_result[0], reference_result[0]);  // Ожидаем одинаковое количество предложений
+    
+    ASSERT_EQ(global_result[0], reference_result[0]);  
   }
 }
 
@@ -207,7 +207,7 @@ TEST(shkurinskaya_e_count_sentences_mpi, Test_No_Punctuation) {
     testMpiTaskSequential.run();
     testMpiTaskSequential.post_processing();
 
-    // Проверка результатов
-    ASSERT_EQ(global_result[0], reference_result[0]);  // Ожидаем одинаковое количество предложений
+    
+    ASSERT_EQ(global_result[0], reference_result[0]);  
   }
 }

--- a/tasks/mpi/shkurinskaya_e_count_sentences/func_tests/main.cpp
+++ b/tasks/mpi/shkurinskaya_e_count_sentences/func_tests/main.cpp
@@ -7,6 +7,46 @@
 
 #include "mpi/shkurinskaya_e_count_sentences/include/ops_mpi.hpp"
 
+TEST(shkurinskaya_e_count_sentences_mpi, Test_Random_String) {
+  boost::mpi::communicator world;
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<> char_dist(32, 126);
+  std::string input_text;
+  int string_length = 1000;
+  for (int i = 0; i < string_length; ++i) {
+    input_text += static_cast<char>(char_dist(gen));
+  }
+  std::vector<int> global_result(1, 0);
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&input_text));
+    taskDataPar->inputs_count.emplace_back(input_text.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_result.data()));
+    taskDataPar->outputs_count.emplace_back(global_result.size());
+  }
+  shkurinskaya_e_count_sentences_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+  if (world.rank() == 0) {
+    std::vector<int> reference_result(1, 0);
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&input_text));
+    taskDataSeq->inputs_count.emplace_back(input_text.size());
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(reference_result.data()));
+    taskDataSeq->outputs_count.emplace_back(reference_result.size());
+    
+    shkurinskaya_e_count_sentences_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+    ASSERT_EQ(global_result[0], reference_result[0]);
+  }
+}
+
 TEST(shkurinskaya_e_count_sentences_mpi, Test_Count_Sentences) {
   boost::mpi::communicator world;
   std::string input_text;

--- a/tasks/mpi/shkurinskaya_e_count_sentences/func_tests/main.cpp
+++ b/tasks/mpi/shkurinskaya_e_count_sentences/func_tests/main.cpp
@@ -201,7 +201,7 @@ TEST(shkurinskaya_e_count_sentences_mpi, Test_No_Punctuation) {
     testMpiTaskSequential.pre_processing();
     testMpiTaskSequential.run();
     testMpiTaskSequential.post_processing();
-    
+
     ASSERT_EQ(global_result[0], reference_result[0]);
   }
 }

--- a/tasks/mpi/shkurinskaya_e_count_sentences/func_tests/main.cpp
+++ b/tasks/mpi/shkurinskaya_e_count_sentences/func_tests/main.cpp
@@ -94,7 +94,7 @@ TEST(shkurinskaya_e_count_sentences_mpi, Test_Multiple_Endings) {
   // Create TaskData for parallel execution
   std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {
-    input_text = "Wow!! Really?! That's amazing.";
+    input_text = "Wow!! Really?! That's amazing...";
     taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&input_text));
     taskDataPar->inputs_count.emplace_back(input_text.size());
     taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_result.data()));

--- a/tasks/mpi/shkurinskaya_e_count_sentences/func_tests/main.cpp
+++ b/tasks/mpi/shkurinskaya_e_count_sentences/func_tests/main.cpp
@@ -38,7 +38,7 @@ TEST(shkurinskaya_e_count_sentences_mpi, Test_Random_String) {
     taskDataSeq->inputs_count.emplace_back(input_text.size());
     taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(reference_result.data()));
     taskDataSeq->outputs_count.emplace_back(reference_result.size());
-    
+
     shkurinskaya_e_count_sentences_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
     ASSERT_EQ(testMpiTaskSequential.validation(), true);
     testMpiTaskSequential.pre_processing();

--- a/tasks/mpi/shkurinskaya_e_count_sentences/func_tests/main.cpp
+++ b/tasks/mpi/shkurinskaya_e_count_sentences/func_tests/main.cpp
@@ -1,0 +1,213 @@
+#include <gtest/gtest.h>
+
+#include <boost/mpi/communicator.hpp>
+#include <boost/mpi/environment.hpp>
+#include <string>
+#include <vector>
+
+#include "mpi/shkurinskaya_e_count_sentences/include/ops_mpi.hpp"
+
+TEST(shkurinskaya_e_count_sentences_mpi, Test_Count_Sentences) {
+  boost::mpi::communicator world;
+  std::string input_text;
+  std::vector<int> global_result(1, 0);
+
+  // Create TaskData for parallel execution
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    input_text = "Hello world! This is a test. Let's see if it works?";
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&input_text));
+    taskDataPar->inputs_count.emplace_back(input_text.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_result.data()));
+    taskDataPar->outputs_count.emplace_back(global_result.size());
+  }
+
+  shkurinskaya_e_count_sentences_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    // Create TaskData for sequential execution
+    std::vector<int> reference_result(1, 0);
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&input_text));
+    taskDataSeq->inputs_count.emplace_back(input_text.size());
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(reference_result.data()));
+    taskDataSeq->outputs_count.emplace_back(reference_result.size());
+
+    shkurinskaya_e_count_sentences_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+
+    // Проверка результатов
+    ASSERT_EQ(global_result[0], reference_result[0]);  // Ожидаем одинаковое количество предложений
+  }
+}
+
+TEST(shkurinskaya_e_count_sentences_mpi, Test_Empty_Text) {
+  boost::mpi::communicator world;
+  std::string input_text;
+  std::vector<int> global_result(1, 0);
+
+  // Create TaskData for parallel execution
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    input_text = "";
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&input_text));
+    taskDataPar->inputs_count.emplace_back(input_text.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_result.data()));
+    taskDataPar->outputs_count.emplace_back(global_result.size());
+  }
+
+  shkurinskaya_e_count_sentences_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    // Create TaskData for sequential execution
+    std::vector<int> reference_result(1, 0);
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&input_text));
+    taskDataSeq->inputs_count.emplace_back(input_text.size());
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(reference_result.data()));
+    taskDataSeq->outputs_count.emplace_back(reference_result.size());
+
+    shkurinskaya_e_count_sentences_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+
+    // Проверка результатов
+    ASSERT_EQ(global_result[0], reference_result[0]);  // Ожидаем одинаковое количество предложений
+  }
+}
+
+TEST(shkurinskaya_e_count_sentences_mpi, Test_Multiple_Endings) {
+  boost::mpi::communicator world;
+  std::string input_text;
+  std::vector<int> global_result(1, 0);
+
+  // Create TaskData for parallel execution
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    input_text = "Wow!!! Really??! That's amazing.";
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&input_text));
+    taskDataPar->inputs_count.emplace_back(input_text.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_result.data()));
+    taskDataPar->outputs_count.emplace_back(global_result.size());
+  }
+
+  shkurinskaya_e_count_sentences_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    // Create TaskData for sequential execution
+    std::vector<int> reference_result(1, 0);
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&input_text));
+    taskDataSeq->inputs_count.emplace_back(input_text.size());
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(reference_result.data()));
+    taskDataSeq->outputs_count.emplace_back(reference_result.size());
+
+    shkurinskaya_e_count_sentences_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+
+    // Проверка результатов
+    ASSERT_EQ(global_result[0], reference_result[0]);  // Ожидаем одинаковое количество предложений
+  }
+}
+
+TEST(shkurinskaya_e_count_sentences_mpi, Test_Single_Sentence) {
+  boost::mpi::communicator world;
+  std::string input_text;
+  std::vector<int> global_result(1, 0);
+
+  // Create TaskData for parallel execution
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    input_text = "This is just one sentence.";
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&input_text));
+    taskDataPar->inputs_count.emplace_back(input_text.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_result.data()));
+    taskDataPar->outputs_count.emplace_back(global_result.size());
+  }
+
+  shkurinskaya_e_count_sentences_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    // Create TaskData for sequential execution
+    std::vector<int> reference_result(1, 0);
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&input_text));
+    taskDataSeq->inputs_count.emplace_back(input_text.size());
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(reference_result.data()));
+    taskDataSeq->outputs_count.emplace_back(reference_result.size());
+
+    shkurinskaya_e_count_sentences_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+
+    // Проверка результатов
+    ASSERT_EQ(global_result[0], reference_result[0]);  // Ожидаем одинаковое количество предложений
+  }
+}
+
+TEST(shkurinskaya_e_count_sentences_mpi, Test_No_Punctuation) {
+  boost::mpi::communicator world;
+  std::string input_text;
+  std::vector<int> global_result(1, 0);
+
+  // Create TaskData for parallel execution
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    input_text = "This text has no punctuation and therefore should count as zero sentences";
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&input_text));
+    taskDataPar->inputs_count.emplace_back(input_text.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_result.data()));
+    taskDataPar->outputs_count.emplace_back(global_result.size());
+  }
+
+  shkurinskaya_e_count_sentences_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    // Create TaskData for sequential execution
+    std::vector<int> reference_result(1, 0);
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&input_text));
+    taskDataSeq->inputs_count.emplace_back(input_text.size());
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(reference_result.data()));
+    taskDataSeq->outputs_count.emplace_back(reference_result.size());
+
+    shkurinskaya_e_count_sentences_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+
+    // Проверка результатов
+    ASSERT_EQ(global_result[0], reference_result[0]);  // Ожидаем одинаковое количество предложений
+  }
+}

--- a/tasks/mpi/shkurinskaya_e_count_sentences/func_tests/main.cpp
+++ b/tasks/mpi/shkurinskaya_e_count_sentences/func_tests/main.cpp
@@ -2,9 +2,9 @@
 
 #include <boost/mpi/communicator.hpp>
 #include <boost/mpi/environment.hpp>
+#include <random>
 #include <string>
 #include <vector>
-#include <random>
 
 #include "mpi/shkurinskaya_e_count_sentences/include/ops_mpi.hpp"
 

--- a/tasks/mpi/shkurinskaya_e_count_sentences/func_tests/main.cpp
+++ b/tasks/mpi/shkurinskaya_e_count_sentences/func_tests/main.cpp
@@ -4,6 +4,7 @@
 #include <boost/mpi/environment.hpp>
 #include <string>
 #include <vector>
+#include <random>
 
 #include "mpi/shkurinskaya_e_count_sentences/include/ops_mpi.hpp"
 

--- a/tasks/mpi/shkurinskaya_e_count_sentences/include/ops_mpi.hpp
+++ b/tasks/mpi/shkurinskaya_e_count_sentences/include/ops_mpi.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <boost/mpi/collectives.hpp>
+#include <boost/mpi/communicator.hpp>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace shkurinskaya_e_count_sentences_mpi {
+
+class TestMPITaskSequential : public ppc::core::Task {
+ public:
+  explicit TestMPITaskSequential(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  std::string text;
+  int res{};
+};
+
+class TestMPITaskParallel : public ppc::core::Task {
+ public:
+  explicit TestMPITaskParallel(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  std::string text, local_input_;
+  int res{};
+  int local_res{};
+  boost::mpi::communicator world;
+};
+
+}  // namespace shkurinskaya_e_count_sentences_mpi

--- a/tasks/mpi/shkurinskaya_e_count_sentences/include/ops_mpi.hpp
+++ b/tasks/mpi/shkurinskaya_e_count_sentences/include/ops_mpi.hpp
@@ -5,10 +5,8 @@
 #include <boost/mpi/collectives.hpp>
 #include <boost/mpi/communicator.hpp>
 #include <memory>
-#include <numeric>
 #include <string>
 #include <utility>
-#include <vector>
 
 #include "core/task/include/task.hpp"
 

--- a/tasks/mpi/shkurinskaya_e_count_sentences/perf_tests/main.cpp
+++ b/tasks/mpi/shkurinskaya_e_count_sentences/perf_tests/main.cpp
@@ -1,0 +1,86 @@
+#include <gtest/gtest.h>
+
+#include <boost/mpi/timer.hpp>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "mpi/shkurinskaya_e_count_sentences/include/ops_mpi.hpp"
+
+TEST(shkurinskaya_e_count_sentences_mpi, test_pipeline_run) {
+  boost::mpi::communicator world;
+  std::string input_text;
+  std::vector<int> global_result(1, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    input_text = "This is another test. I love testing stuff! Don't you like it too?";
+    for (int i = 0; i < 999999; i++) {
+      input_text += "Let's do it " + std::to_string(i + 1) + " time!";
+    }
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&input_text));
+    taskDataPar->inputs_count.emplace_back(input_text.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_result.data()));
+    taskDataPar->outputs_count.emplace_back(global_result.size());
+  }
+
+  auto testMpiTaskParallel =
+      std::make_shared<shkurinskaya_e_count_sentences_mpi::TestMPITaskParallel>(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel->validation(), true);
+  testMpiTaskParallel->pre_processing();
+  testMpiTaskParallel->run();
+  testMpiTaskParallel->post_processing();
+
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testMpiTaskParallel);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+  if (world.rank() == 0) {
+    ppc::core::Perf::print_perf_statistic(perfResults);
+    ASSERT_EQ(1000002, global_result[0]);
+  }
+}
+
+TEST(shkurinskaya_e_count_sentences_mpi, test_task_run) {
+  boost::mpi::communicator world;
+  std::string input_text;
+  std::vector<int> global_result(1, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    input_text = "This is another test. I love testing stuff! Don't you like it too?";
+    for (int i = 0; i < 999999; i++) {
+      input_text += "Let's do it " + std::to_string(i + 1) + " time!";
+    }
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&input_text));
+    taskDataPar->inputs_count.emplace_back(input_text.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_result.data()));
+    taskDataPar->outputs_count.emplace_back(global_result.size());
+  }
+
+
+  auto testMpiTaskParallel =
+      std::make_shared<shkurinskaya_e_count_sentences_mpi::TestMPITaskParallel>(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel->validation(), true);
+  testMpiTaskParallel->pre_processing();
+  testMpiTaskParallel->run();
+  testMpiTaskParallel->post_processing();
+
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testMpiTaskParallel);
+  perfAnalyzer->task_run(perfAttr, perfResults);
+  if (world.rank() == 0) {
+    ppc::core::Perf::print_perf_statistic(perfResults);
+    ASSERT_EQ(1000002, global_result[0]);
+  }
+}

--- a/tasks/mpi/shkurinskaya_e_count_sentences/perf_tests/main.cpp
+++ b/tasks/mpi/shkurinskaya_e_count_sentences/perf_tests/main.cpp
@@ -23,8 +23,7 @@ TEST(shkurinskaya_e_count_sentences_mpi, test_pipeline_run) {
     taskDataPar->outputs_count.emplace_back(global_result.size());
   }
 
-  auto testMpiTaskParallel =
-      std::make_shared<shkurinskaya_e_count_sentences_mpi::TestMPITaskParallel>(taskDataPar);
+  auto testMpiTaskParallel = std::make_shared<shkurinskaya_e_count_sentences_mpi::TestMPITaskParallel>(taskDataPar);
   ASSERT_EQ(testMpiTaskParallel->validation(), true);
   testMpiTaskParallel->pre_processing();
   testMpiTaskParallel->run();
@@ -62,9 +61,7 @@ TEST(shkurinskaya_e_count_sentences_mpi, test_task_run) {
     taskDataPar->outputs_count.emplace_back(global_result.size());
   }
 
-
-  auto testMpiTaskParallel =
-      std::make_shared<shkurinskaya_e_count_sentences_mpi::TestMPITaskParallel>(taskDataPar);
+  auto testMpiTaskParallel = std::make_shared<shkurinskaya_e_count_sentences_mpi::TestMPITaskParallel>(taskDataPar);
   ASSERT_EQ(testMpiTaskParallel->validation(), true);
   testMpiTaskParallel->pre_processing();
   testMpiTaskParallel->run();

--- a/tasks/mpi/shkurinskaya_e_count_sentences/src/ops_mpi.cpp
+++ b/tasks/mpi/shkurinskaya_e_count_sentences/src/ops_mpi.cpp
@@ -63,7 +63,8 @@ bool shkurinskaya_e_count_sentences_mpi::TestMPITaskParallel::validation() {
 
 bool shkurinskaya_e_count_sentences_mpi::TestMPITaskParallel::run() {
   internal_order_test();
-  size_t delta, remainder;
+  size_t delta;
+  size_t remainder;
   if (world.rank() == 0) {
     size_t total_size = text.size();
     delta = total_size / world.size();

--- a/tasks/mpi/shkurinskaya_e_count_sentences/src/ops_mpi.cpp
+++ b/tasks/mpi/shkurinskaya_e_count_sentences/src/ops_mpi.cpp
@@ -7,10 +7,8 @@
 #include <string>
 #include <thread>
 #include <vector>
-#include <iostream>
 
 using namespace std::chrono_literals;
-
 bool shkurinskaya_e_count_sentences_mpi::TestMPITaskSequential::pre_processing() {
   internal_order_test();
   text = *reinterpret_cast<std::string*>(taskData->inputs[0]);
@@ -53,25 +51,22 @@ bool shkurinskaya_e_count_sentences_mpi::TestMPITaskParallel::pre_processing() {
     text = *reinterpret_cast<std::string*>(taskData->inputs[0]);
   }
 
-  
   size_t total_size = text.size();
   size_t delta = total_size / world.size();
   size_t remainder = total_size % world.size();
   broadcast(world, delta, 0);
   broadcast(world, remainder, 0);
 
- 
-  if (world.rank() == 0) {
+ if (world.rank() == 0) {
     for (int proc = 1; proc < world.size(); ++proc) {
       size_t start_index = proc * delta;
+      
       size_t length = (proc == world.size() - 1) ? delta + remainder : delta;  
       world.send(proc, 0, text.data() + start_index, length);
     }
-    
     size_t length = (world.size() == 1) ? total_size : delta;  
     local_input_.assign(text.begin(), text.begin() + length);
   } else {
-    
     size_t length = (world.rank() == world.size() - 1) ? delta + remainder : delta;
     local_input_.resize(length);
     world.recv(0, 0, local_input_.data(), length);
@@ -81,7 +76,6 @@ bool shkurinskaya_e_count_sentences_mpi::TestMPITaskParallel::pre_processing() {
   res = 0;
   return true;
 }
-
 
 bool shkurinskaya_e_count_sentences_mpi::TestMPITaskParallel::validation() {
   internal_order_test();
@@ -107,8 +101,7 @@ bool shkurinskaya_e_count_sentences_mpi::TestMPITaskParallel::run() {
     }
   }
 
-   reduce
-  boost::mpi::reduce(world, local_res, res, std::plus<>(), 0);
+  reduce boost::mpi::reduce(world, local_res, res, std::plus<>(), 0);;
   return true;
 }
 

--- a/tasks/mpi/shkurinskaya_e_count_sentences/src/ops_mpi.cpp
+++ b/tasks/mpi/shkurinskaya_e_count_sentences/src/ops_mpi.cpp
@@ -48,27 +48,6 @@ bool shkurinskaya_e_count_sentences_mpi::TestMPITaskParallel::pre_processing() {
   if (world.rank() == 0) {
     text = *reinterpret_cast<std::string*>(taskData->inputs[0]);
   }
-
-  size_t total_size = text.size();
-  size_t delta = total_size / world.size();
-  size_t remainder = total_size % world.size();
-  broadcast(world, delta, 0);
-  broadcast(world, remainder, 0);
-
-  if (world.rank() == 0) {
-    for (int proc = 1; proc < world.size(); ++proc) {
-      size_t start_index = proc * delta;
-      size_t length = (proc == world.size() - 1) ? delta + remainder : delta;
-      world.send(proc, 0, text.data() + start_index, length);
-    }
-    size_t length = (world.size() == 1) ? total_size : delta;
-    local_input_.assign(text.begin(), text.begin() + length);
-  } else {
-    size_t length = (world.rank() == world.size() - 1) ? delta + remainder : delta;
-    local_input_.resize(length);
-    world.recv(0, 0, local_input_.data(), length);
-  }
-
   local_res = 0;
   res = 0;
   return true;
@@ -84,8 +63,28 @@ bool shkurinskaya_e_count_sentences_mpi::TestMPITaskParallel::validation() {
 
 bool shkurinskaya_e_count_sentences_mpi::TestMPITaskParallel::run() {
   internal_order_test();
+  size_t delta, remainder;
+  if (world.rank() == 0) {
+    size_t total_size = text.size();
+    delta = total_size / world.size();
+    remainder = total_size % world.size();
+  }
+  broadcast(world, delta, 0);
+  broadcast(world, remainder, 0);
+  if (world.rank() == 0) {
+    for (int proc = 1; proc < world.size(); ++proc) {
+      size_t start_index = proc * delta;
+      size_t length = (proc == world.size() - 1) ? delta + remainder : delta;
+      world.send(proc, 0, text.data() + start_index, length);
+    }
+    size_t length = (world.size() == 1) ? text.size() : delta;
+    local_input_.assign(text.begin(), text.begin() + length);
+  } else {
+    size_t length = (world.rank() == world.size() - 1) ? delta + remainder : delta;
+    local_input_.resize(length);
+    world.recv(0, 0, local_input_.data(), length);
+  }
   bool in_end = false;
-
   for (size_t i = 0; i < local_input_.size(); ++i) {
     char ch = local_input_[i];
     if (ch == '!' || ch == '?' || ch == '.') {
@@ -97,7 +96,6 @@ bool shkurinskaya_e_count_sentences_mpi::TestMPITaskParallel::run() {
       in_end = false;
     }
   }
-
   boost::mpi::reduce(world, local_res, res, std::plus<>(), 0);
   return true;
 }

--- a/tasks/mpi/shkurinskaya_e_count_sentences/src/ops_mpi.cpp
+++ b/tasks/mpi/shkurinskaya_e_count_sentences/src/ops_mpi.cpp
@@ -98,7 +98,7 @@ bool shkurinskaya_e_count_sentences_mpi::TestMPITaskParallel::run() {
     }
   }
 
-  reduce boost::mpi::reduce(world, local_res, res, std::plus<>(), 0);
+  boost::mpi::reduce(world, local_res, res, std::plus<>(), 0);
   return true;
 }
 

--- a/tasks/mpi/shkurinskaya_e_count_sentences/src/ops_mpi.cpp
+++ b/tasks/mpi/shkurinskaya_e_count_sentences/src/ops_mpi.cpp
@@ -43,7 +43,6 @@ bool shkurinskaya_e_count_sentences_mpi::TestMPITaskSequential::post_processing(
   return true;
 }
 
-
 bool shkurinskaya_e_count_sentences_mpi::TestMPITaskParallel::pre_processing() {
   internal_order_test();
   if (world.rank() == 0) {
@@ -59,10 +58,10 @@ bool shkurinskaya_e_count_sentences_mpi::TestMPITaskParallel::pre_processing() {
   if (world.rank() == 0) {
     for (int proc = 1; proc < world.size(); ++proc) {
       size_t start_index = proc * delta;
-      size_t length = (proc == world.size() - 1) ? delta + remainder : delta;  
+      size_t length = (proc == world.size() - 1) ? delta + remainder : delta;
       world.send(proc, 0, text.data() + start_index, length);
     }
-    size_t length = (world.size() == 1) ? total_size : delta;  
+    size_t length = (world.size() == 1) ? total_size : delta;
     local_input_.assign(text.begin(), text.begin() + length);
   } else {
     size_t length = (world.rank() == world.size() - 1) ? delta + remainder : delta;

--- a/tasks/mpi/shkurinskaya_e_count_sentences/src/ops_mpi.cpp
+++ b/tasks/mpi/shkurinskaya_e_count_sentences/src/ops_mpi.cpp
@@ -53,25 +53,25 @@ bool shkurinskaya_e_count_sentences_mpi::TestMPITaskParallel::pre_processing() {
     text = *reinterpret_cast<std::string*>(taskData->inputs[0]);
   }
 
-  // Определение размера блока для каждого процесса
+  
   size_t total_size = text.size();
   size_t delta = total_size / world.size();
   size_t remainder = total_size % world.size();
   broadcast(world, delta, 0);
   broadcast(world, remainder, 0);
 
- // Главный процесс отправляет части текста остальным процессам
+ 
   if (world.rank() == 0) {
     for (int proc = 1; proc < world.size(); ++proc) {
       size_t start_index = proc * delta;
-      size_t length = (proc == world.size() - 1) ? delta + remainder : delta;  // Последний процесс получает остаток
+      size_t length = (proc == world.size() - 1) ? delta + remainder : delta;  
       world.send(proc, 0, text.data() + start_index, length);
     }
-    // Главный процесс сохраняет свою часть текста
-    size_t length = (world.size() == 1) ? total_size : delta;  // Если только один процесс, он получает весь текст
+    
+    size_t length = (world.size() == 1) ? total_size : delta;  
     local_input_.assign(text.begin(), text.begin() + length);
   } else {
-    // Остальные процессы получают свои части текста
+    
     size_t length = (world.rank() == world.size() - 1) ? delta + remainder : delta;
     local_input_.resize(length);
     world.recv(0, 0, local_input_.data(), length);
@@ -107,7 +107,7 @@ bool shkurinskaya_e_count_sentences_mpi::TestMPITaskParallel::run() {
     }
   }
 
-  // Суммируем результаты с помощью reduce
+   reduce
   boost::mpi::reduce(world, local_res, res, std::plus<>(), 0);
   return true;
 }

--- a/tasks/mpi/shkurinskaya_e_count_sentences/src/ops_mpi.cpp
+++ b/tasks/mpi/shkurinskaya_e_count_sentences/src/ops_mpi.cpp
@@ -15,7 +15,6 @@ bool shkurinskaya_e_count_sentences_mpi::TestMPITaskSequential::pre_processing()
   res = 0;
   return true;
 }
-
 bool shkurinskaya_e_count_sentences_mpi::TestMPITaskSequential::validation() {
   internal_order_test();
   return taskData->outputs_count[0] == 1;
@@ -57,10 +56,9 @@ bool shkurinskaya_e_count_sentences_mpi::TestMPITaskParallel::pre_processing() {
   broadcast(world, delta, 0);
   broadcast(world, remainder, 0);
 
- if (world.rank() == 0) {
+  if (world.rank() == 0) {
     for (int proc = 1; proc < world.size(); ++proc) {
       size_t start_index = proc * delta;
-      
       size_t length = (proc == world.size() - 1) ? delta + remainder : delta;  
       world.send(proc, 0, text.data() + start_index, length);
     }
@@ -101,7 +99,7 @@ bool shkurinskaya_e_count_sentences_mpi::TestMPITaskParallel::run() {
     }
   }
 
-  reduce boost::mpi::reduce(world, local_res, res, std::plus<>(), 0);;
+  reduce boost::mpi::reduce(world, local_res, res, std::plus<>(), 0);
   return true;
 }
 

--- a/tasks/mpi/shkurinskaya_e_count_sentences/src/ops_mpi.cpp
+++ b/tasks/mpi/shkurinskaya_e_count_sentences/src/ops_mpi.cpp
@@ -1,0 +1,121 @@
+#include "mpi/shkurinskaya_e_count_sentences/include/ops_mpi.hpp"
+
+#include <algorithm>
+#include <boost/mpi.hpp>
+#include <functional>
+#include <random>
+#include <string>
+#include <thread>
+#include <vector>
+#include <iostream>
+
+using namespace std::chrono_literals;
+
+bool shkurinskaya_e_count_sentences_mpi::TestMPITaskSequential::pre_processing() {
+  internal_order_test();
+  text = *reinterpret_cast<std::string*>(taskData->inputs[0]);
+  res = 0;
+  return true;
+}
+
+bool shkurinskaya_e_count_sentences_mpi::TestMPITaskSequential::validation() {
+  internal_order_test();
+  return taskData->outputs_count[0] == 1;
+}
+
+bool shkurinskaya_e_count_sentences_mpi::TestMPITaskSequential::run() {
+  internal_order_test();
+  bool in_end = false;
+  for (size_t i = 0; i < text.size(); i++) {
+    char ch = text[i];
+    if (ch == '!' || ch == '?' || ch == '.') {
+      if (!in_end) {
+        res++;
+        in_end = true;
+      }
+    } else if (ch != ' ') {
+      in_end = false;
+    }
+  }
+  return true;
+}
+
+bool shkurinskaya_e_count_sentences_mpi::TestMPITaskSequential::post_processing() {
+  internal_order_test();
+  reinterpret_cast<int*>(taskData->outputs[0])[0] = res;
+  return true;
+}
+
+
+bool shkurinskaya_e_count_sentences_mpi::TestMPITaskParallel::pre_processing() {
+  internal_order_test();
+  if (world.rank() == 0) {
+    text = *reinterpret_cast<std::string*>(taskData->inputs[0]);
+  }
+
+  // Определение размера блока для каждого процесса
+  size_t total_size = text.size();
+  size_t delta = total_size / world.size();
+  size_t remainder = total_size % world.size();
+  broadcast(world, delta, 0);
+  broadcast(world, remainder, 0);
+
+ // Главный процесс отправляет части текста остальным процессам
+  if (world.rank() == 0) {
+    for (int proc = 1; proc < world.size(); ++proc) {
+      size_t start_index = proc * delta;
+      size_t length = (proc == world.size() - 1) ? delta + remainder : delta;  // Последний процесс получает остаток
+      world.send(proc, 0, text.data() + start_index, length);
+    }
+    // Главный процесс сохраняет свою часть текста
+    size_t length = (world.size() == 1) ? total_size : delta;  // Если только один процесс, он получает весь текст
+    local_input_.assign(text.begin(), text.begin() + length);
+  } else {
+    // Остальные процессы получают свои части текста
+    size_t length = (world.rank() == world.size() - 1) ? delta + remainder : delta;
+    local_input_.resize(length);
+    world.recv(0, 0, local_input_.data(), length);
+  }
+
+  local_res = 0;
+  res = 0;
+  return true;
+}
+
+
+bool shkurinskaya_e_count_sentences_mpi::TestMPITaskParallel::validation() {
+  internal_order_test();
+  if (world.rank() == 0) {
+    return taskData->outputs_count[0] == 1;
+  }
+  return true;
+}
+
+bool shkurinskaya_e_count_sentences_mpi::TestMPITaskParallel::run() {
+  internal_order_test();
+  bool in_end = false;
+
+  for (size_t i = 0; i < local_input_.size(); ++i) {
+    char ch = local_input_[i];
+    if (ch == '!' || ch == '?' || ch == '.') {
+      if (!in_end) {
+        local_res++;
+        in_end = true;
+      }
+    } else if (ch != ' ') {
+      in_end = false;
+    }
+  }
+
+  // Суммируем результаты с помощью reduce
+  boost::mpi::reduce(world, local_res, res, std::plus<>(), 0);
+  return true;
+}
+
+bool shkurinskaya_e_count_sentences_mpi::TestMPITaskParallel::post_processing() {
+  internal_order_test();
+  if (world.rank() == 0) {
+    reinterpret_cast<int*>(taskData->outputs[0])[0] = res;
+  }
+  return true;
+}

--- a/tasks/seq/shkurinskaya_e_count_sentences/func_tests/main.cpp
+++ b/tasks/seq/shkurinskaya_e_count_sentences/func_tests/main.cpp
@@ -68,7 +68,7 @@ TEST(Sequential, Test_Complex_Punctuation) {
 }
 
 TEST(Sequential, Test_Empty_Sentence) {
-  std::string input_text = "";
+  std::string input_text;
   int expected_count = 0;
 
   std::vector<std::string> in(1, input_text);

--- a/tasks/seq/shkurinskaya_e_count_sentences/func_tests/main.cpp
+++ b/tasks/seq/shkurinskaya_e_count_sentences/func_tests/main.cpp
@@ -1,0 +1,89 @@
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "seq/shkurinskaya_e_count_sentences/include/ops_seq.hpp"
+
+TEST(Sequential, Test_Single_Sentence) {
+  std::string input_text = "One sentence!";
+  int expected_count = 1;
+
+  std::vector<std::string> in(1, input_text);
+  std::vector<int> out(1, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskDataSeq->inputs_count.emplace_back(in.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  shkurinskaya_e_count_sentences::TestTaskSequential testTaskSequential(taskDataSeq);
+  ASSERT_EQ(testTaskSequential.validation(), true);
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+  ASSERT_EQ(expected_count, out[0]);
+}
+
+TEST(Sequential, Test_Different_Punctuation_Marks) {
+  std::string input_text = "I have never visited Paris before. Never visited what? Paris!";
+  int expected_count = 3;
+
+  std::vector<std::string> in(1, input_text);
+  std::vector<int> out(1, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskDataSeq->inputs_count.emplace_back(in.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  shkurinskaya_e_count_sentences::TestTaskSequential testTaskSequential(taskDataSeq);
+  ASSERT_EQ(testTaskSequential.validation(), true);
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+  ASSERT_EQ(expected_count, out[0]);
+}
+
+TEST(Sequential, Test_Complex_Punctuation) {
+  std::string input_text = "This is the first sentence! But wait... Is it? There's more.";
+  int expected_count = 4;
+
+  std::vector<std::string> in(1, input_text);
+  std::vector<int> out(1, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskDataSeq->inputs_count.emplace_back(in.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  shkurinskaya_e_count_sentences::TestTaskSequential testTaskSequential(taskDataSeq);
+  ASSERT_EQ(testTaskSequential.validation(), true);
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+  ASSERT_EQ(expected_count, out[0]);
+}
+
+TEST(Sequential, Test_Empty_Sentence) {
+  std::string input_text = "";
+  int expected_count = 0;
+
+  std::vector<std::string> in(1, input_text);
+  std::vector<int> out(1, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskDataSeq->inputs_count.emplace_back(in.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  shkurinskaya_e_count_sentences::TestTaskSequential testTaskSequential(taskDataSeq);
+  ASSERT_EQ(testTaskSequential.validation(), true);
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+  ASSERT_EQ(expected_count, out[0]);
+}

--- a/tasks/seq/shkurinskaya_e_count_sentences/include/ops_seq.hpp
+++ b/tasks/seq/shkurinskaya_e_count_sentences/include/ops_seq.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace shkurinskaya_e_count_sentences {
+
+class TestTaskSequential : public ppc::core::Task {
+ public:
+  explicit TestTaskSequential(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  std::string text{};
+  int res{};
+};
+
+}  // namespace shkurinskaya_e_count_sentences

--- a/tasks/seq/shkurinskaya_e_count_sentences/perf_tests/main.cpp
+++ b/tasks/seq/shkurinskaya_e_count_sentences/perf_tests/main.cpp
@@ -1,0 +1,74 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+
+#include "core/perf/include/perf.hpp"
+#include "seq/shkurinskaya_e_count_sentences/include/ops_seq.hpp"
+
+TEST(shkurinskaya_e_count_sentences, test_pipeline_run) {
+  std::string input_text = "This is another test. I love testing stuff! Don't you like it too?";
+
+  std::vector<int> out(1, 0);
+  for (int i = 0; i < 999999; i++) {
+    input_text += "Let's do it " + std::to_string(i + 1) + " time!";
+  }
+  std::vector<std::string> in(1, input_text);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskDataSeq->inputs_count.emplace_back(in.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  auto testTaskSequential = std::make_shared<shkurinskaya_e_count_sentences::TestTaskSequential>(taskDataSeq);
+
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testTaskSequential);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+  ppc::core::Perf::print_perf_statistic(perfResults);
+  ASSERT_EQ(1000002, out[0]);
+}
+
+TEST(shkurinskaya_e_count_sentences, test_task_run) {
+  std::string input_text = "This is another test. I love testing stuff! Don't you like it too?";
+
+  std::vector<int> out(1, 0);
+  for (int i = 0; i < 999999; i++) {
+    input_text += "Let's do it " + std::to_string(i + 1) + " time!";
+  }
+  std::vector<std::string> in(1, input_text);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskDataSeq->inputs_count.emplace_back(in.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  auto testTaskSequential = std::make_shared<shkurinskaya_e_count_sentences::TestTaskSequential>(taskDataSeq);
+
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testTaskSequential);
+  perfAnalyzer->task_run(perfAttr, perfResults);
+  ppc::core::Perf::print_perf_statistic(perfResults);
+  ASSERT_EQ(1000002, out[0]);
+}

--- a/tasks/seq/shkurinskaya_e_count_sentences/src/ops_seq.cpp
+++ b/tasks/seq/shkurinskaya_e_count_sentences/src/ops_seq.cpp
@@ -1,0 +1,40 @@
+#include "seq/shkurinskaya_e_count_sentences/include/ops_seq.hpp"
+
+#include <thread>
+
+using namespace std::chrono_literals;
+
+bool shkurinskaya_e_count_sentences::TestTaskSequential::pre_processing() {
+  internal_order_test();
+  text = *reinterpret_cast<std::string*>(taskData->inputs[0]);
+  res = 0;
+  return true;
+}
+
+bool shkurinskaya_e_count_sentences::TestTaskSequential::validation() {
+  internal_order_test();
+  return taskData->outputs_count[0] == 1;
+}
+
+bool shkurinskaya_e_count_sentences::TestTaskSequential::run() {
+  internal_order_test();
+  bool in_end = false;
+  for (size_t i = 0; i < text.size(); i++) {
+    char ch = text[i];
+    if (ch == '!' || ch == '?' || ch == '.') {
+      if (!in_end) {
+        res++;
+        in_end = true;
+      }
+    } else if (ch != ' ') {
+      in_end = false;
+    }
+  }
+  return true;
+}
+
+bool shkurinskaya_e_count_sentences::TestTaskSequential::post_processing() {
+  internal_order_test();
+  reinterpret_cast<int*>(taskData->outputs[0])[0] = res;
+  return true;
+}


### PR DESCRIPTION
Последовательно: подаётся строка, проходим по ней и считаем число предложений по знакам препинания.
MPI: главный процесс (rank 0) разделяет строку на равные части и передает их всем процессам с помощью MPI broadcast. Последний процесс получает остаток строки, если она не делится равномерно. Каждый процесс считает количество предложений в своей части строки, после этого расчёты объединяются через MPI reduce.